### PR TITLE
chore: add Playwright and Git MCP server config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
-tests/state.json
+/tests/state.json
+.playwright-mcp/

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "playwright": {
+      "type": "local",
+      "command": ["npx", "@playwright/mcp@latest"],
+      "enabled": true
+    }
+  }
+}

--- a/opencode.json
+++ b/opencode.json
@@ -5,6 +5,11 @@
       "type": "local",
       "command": ["npx", "@playwright/mcp@latest"],
       "enabled": true
+    },
+    "git": {
+      "type": "local",
+      "command": ["uvx", "mcp-server-git", "--repository", "."],
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds the Playwright MCP server (`@playwright/mcp`) to `opencode.json` so an agent can drive a real browser when developing and debugging tests
- Adds the Git MCP server (`mcp-server-git`) so an agent can inspect repository state (log, diff, blame) without leaving the tool context
- Excludes `.playwright-mcp/` (generated console logs and page snapshots) from version control via `.gitignore`
- Anchors the existing `state.json` ignore rule to the repo root (`/tests/state.json`)

No changes to test code or page objects.

## Test plan

- [ ] Verify `opencode.json` loads both MCP servers without errors
- [ ] Confirm `.playwright-mcp/` artifacts are not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)